### PR TITLE
[GI#6] Add i18n tags in generated templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,10 +63,13 @@ issues when rendering templates.
 
 ### Running Tests
 
-In order to run the test suite, start a Selenium server and issue the following commands:
+In order to run the test suite, install your local version of `django-generate-scaffold`
+and start a Selenium server and issue the following commands:
 
-        cd django-generate-scaffold/test_project
-        python test_app/tests/runtests.py
+        $ cd django-generate-scaffold
+        $ python setup.py install --force
+        $ cd test_project
+        $ python test_app/tests/runtests.py
 
 Consult `.travis.yml` for the exact steps necessary to run the test
 suite.
@@ -76,7 +79,7 @@ suite.
 By installing the gems in the Gemfile, you can automatically run all non-Selenium
 based tests every time a file is modified:
 
-        watchr autotest.rb
+        $ watchr autotest.rb
 
 ### How to Contribute
 

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive.html
@@ -1,26 +1,29 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block title {% templatetag closeblock %}
-  {{ class_name }} Archive Index
+  {% templatetag openblock %} trans "{{ class_name }} Archive Index" {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-        Archive Index
+        {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-    {{ class_name }} Archive Index
+    {% templatetag openblock %} trans "{{ class_name }} Archive Index" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A top-level index page showing the "latest" objects, by date.
+  {% templatetag openblock %} trans "A top-level index page showing the "latest" objects, by date." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
@@ -36,7 +39,7 @@
     {% templatetag openblock %} endfor {% templatetag closeblock %}
   </ul>
   <h2>
-    Recent {{ class_name }}s
+    {% templatetag openblock %} trans "Recent {{ class_name }}s" {% templatetag closeblock %}
   </h2>
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_list.html' {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/pagination.html' {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive.html
@@ -23,7 +23,7 @@
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  {% templatetag openblock %} trans "A top-level index page showing the "latest" objects, by date." {% templatetag closeblock %}
+  {% templatetag openblock %} trans "A top-level index page showing the latest objects, by date." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_day.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_day.html
@@ -1,15 +1,18 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block title {% templatetag closeblock %}
-  {{ class_name }} Day Archive
+  {% templatetag openblock %} trans "{{ class_name }} Day Archive" {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-        Archive Index
+        {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -17,7 +20,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=day.year {% templatetag closeblock %}'>
-        Year Archive
+        {% templatetag openblock %} trans "Year Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -25,7 +28,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=day.year month=day.month {% templatetag closeblock %}'>
-        Month Archive
+        {% templatetag openblock %} trans "Month Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -33,22 +36,24 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=day.year month=day.month day=day.day {% templatetag closeblock %}'>
-        Day Archive
+        {% templatetag openblock %} trans "Day Archive" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=day.year month=day.month day=day.day {% templatetag closeblock %}'>
-    {{ class_name }} Day Archive
+    {% templatetag openblock %} trans "{{ class_name }} Day Archive" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A day archive page showing all objects in a given day.
+  {% templatetag openblock %} trans "A day archive page showing all objects in a given day." {% templatetag openblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
-    {{ class_name }}s created on {% templatetag openvariable %} day {% templatetag closevariable %}
+    {% templatetag openblock %} blocktrans {% templatetag closeblock %}
+      {{ class_name }}s created on {% templatetag openvariable %} day {% templatetag closevariable %}
+    {% templatetag openblock %} endblocktrans {% templatetag closeblock %}
   </h2>
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_list.html' {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/pagination.html' {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_month.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_month.html
@@ -1,4 +1,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
@@ -6,7 +9,7 @@
   <ul class='breadcrumb'>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-        Archive Index
+        {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -14,7 +17,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=month.year {% templatetag closeblock %}'>
-        Year Archive
+        {% templatetag openblock %} trans "Year Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -22,18 +25,18 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=month.year month=month.month {% templatetag closeblock %}'>
-        Month Archive
+        {% templatetag openblock %} trans "Month Archive" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=month.year month=month.month {% templatetag closeblock %}'>
-    {{ class_name }} Month Archive
+    {% templatetag openblock %} trans "{{ class_name }} Month Archive" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A monthly archive page showing all objects in a given month.
+  {% templatetag openblock %} trans "A monthly archive page showing all objects in a given month." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
@@ -49,7 +52,9 @@
     {% templatetag openblock %} endfor {% templatetag closeblock %}
   </ul>
   <h2>
-    {{ class_name }}s created in the month of {% templatetag openvariable %} month|date:"M Y" {% templatetag closevariable %}
+    {% templatetag openblock %} blocktrans {% templatetag closeblock %}
+      {{ class_name }}s created in the month of {% templatetag openvariable %} month|date:"M Y" {% templatetag closevariable %}
+    {% templatetag openblock %} endblocktrans {% templatetag closeblock %}
   </h2>
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_list.html' {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/pagination.html' {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_week.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_week.html
@@ -1,19 +1,24 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block title {% templatetag closeblock %}
-  {{ class_name }} Week Archive
+  {% templatetag openblock %} trans "{{ class_name }} Week Archive" {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  {{ class_name }} Week Archive
+  {% templatetag openblock %} trans "{{ class_name }} Week Archive" {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A weekly archive page showing all objects in a given week.
+  {% templatetag openblock %} trans "A weekly archive page showing all objects in a given week." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
-    {{ class_name }}s created during the week beginning on {% templatetag openvariable %} week {% templatetag closevariable %}
+    {% templatetag openblock %} blocktrans {% templatetag closeblock %}
+      {{ class_name }}s created during the week beginning on {% templatetag openvariable %} week {% templatetag closevariable %}
+    {% templatetag openblock %} endblocktrans {% templatetag closeblock %}
   </h2>
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_list.html' {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/pagination.html' {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_year.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_year.html
@@ -1,4 +1,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
@@ -6,7 +9,7 @@
   <ul class='breadcrumb'>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-        Archive Index
+        {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -14,22 +17,22 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=year {% templatetag closeblock %}'>
-        Year Archive
+        {% templatetag openblock %} trans "Year Archive" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=year {% templatetag closeblock %}'>
-    {{ class_name }} Year Archive
+    {% templatetag openblock %} trans "{{ class_name }} Year Archive" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A yearly archive page showing all available months in a given year.
+  {% templatetag openblock %} trans "A yearly archive page showing all available months in a given year." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
-    By Month
+    {% templatetag openblock %} trans "By Month" {% templatetag closeblock %}
   </h2>
   <ul class='nav nav-tabs nav-stacked'>
     {% templatetag openblock %} for date in date_list {% templatetag closeblock %}
@@ -41,7 +44,9 @@
     {% templatetag openblock %} endfor {% templatetag closeblock %}
   </ul>
   <h2>
-    {{ class_name }}s created in the year {% templatetag openvariable %} year {% templatetag closevariable %}
+    {% templatetag openblock %} blocktrans {% templatetag closeblock %}
+      {{ class_name }}s created in the year {% templatetag openvariable %} year {% templatetag closevariable %}
+    {% templatetag openblock %} endblocktrans {% templatetag closeblock %}
   </h2>
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_list.html' {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/pagination.html' {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_confirm_delete.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_confirm_delete.html
@@ -1,22 +1,24 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block title {% templatetag closeblock %}
-  {{ class_name }} Confirm Delete
+  {% templatetag openblock %} trans "{{ class_name }} Confirm Delete" {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}'>
-    {{ class_name }} Confirm Delete
+    {% templatetag openblock %} trans "{{ class_name }} Confirm Delete" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A view that displays a confirmation page (on GET) and deletes an
-  existing object (on POST).
+  {% templatetag openblock %} trans "A view that displays a confirmation page (on GET) and deletes an existing object (on POST)." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
-    Delete this {{ class_name }}?
+    {% templatetag openblock %} trans "Delete this {{ class_name }}?" {% templatetag closeblock %}
   </h2>
   <br />
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_detail.html' {% templatetag closeblock %}
@@ -25,7 +27,7 @@
       {% templatetag openblock %} csrf_token {% templatetag closeblock %}
       <div class='form-actions'>
         <button class='btn btn-danger' type='submit'>
-          Delete
+          {% templatetag openblock %} trans "Delete" {% templatetag closeblock %}
         </button>
       </div>
     </fieldset>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_detail.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_detail.html
@@ -1,16 +1,19 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block title {% templatetag closeblock %}
-  {{ class_name }} Detail
+  {% templatetag openblock %} trans "{{ class_name }} Detail" {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% if is_timestamped %}
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-        Archive Index
+        {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -18,7 +21,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=object.{{ timestamp_field }}.year {% templatetag closeblock %}'>
-        Year Archive
+        {% templatetag openblock %} trans "Year Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -26,7 +29,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month {% templatetag closeblock %}'>
-        Month Archive
+        {% templatetag openblock %} trans "Month Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -34,7 +37,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day {% templatetag closeblock %}'>
-        Day Archive
+        {% templatetag openblock %} trans "Day Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
         /
@@ -42,7 +45,7 @@
     </li>
     <li>
       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_date_detail year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day pk=object.pk {% templatetag closeblock %}'>
-        Date Detail
+        {% templatetag openblock %} trans "Date Detail" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
@@ -50,25 +53,25 @@
 {% endif %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openvariable %} object.get_absolute_url {% templatetag closevariable %}'>
-    {{ class_name }} Detail
+    {% templatetag openblock %} trans "{{ class_name }} Detail" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A page representing an individual object.
+  {% templatetag openblock %} trans "A page representing an individual object." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_detail.html' {% templatetag closeblock %}
-    <form action='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}' charset='utf-8' method='post'>
-      <fieldset>
-        {% templatetag openblock %} csrf_token {% templatetag closeblock %}
-        <div class='form-actions'>
-          <a class='btn btn-success' href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
-            Update
-          </a>
-          <button class='btn btn-danger' type='submit'>
-            Delete
-          </button>
-        </div>
-      </fieldset>
-    </form>
+  <form action='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}' charset='utf-8' method='post'>
+    <fieldset>
+      {% templatetag openblock %} csrf_token {% templatetag closeblock %}
+      <div class='form-actions'>
+        <a class='btn btn-success' href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
+          {% templatetag openblock %} trans "Update" {% templatetag closeblock %}
+        </a>
+        <button class='btn btn-danger' type='submit'>
+          {% templatetag openblock %} trans "Delete" {% templatetag closeblock %}
+        </button>
+      </div>
+    </fieldset>
+  </form>
 {% templatetag openblock %} endblock {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_form.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_form.html
@@ -1,30 +1,33 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block title {% templatetag closeblock %}
   {% templatetag openblock %} if object {% templatetag closeblock %}
-    Update {{ class_name }}
+    {% templatetag openblock %} trans "Update {{ class_name }}" {% templatetag closeblock %}
   {% templatetag openblock %} else {% templatetag closeblock %}
-    Create a New {{ class_name }}
+    {% templatetag openblock %} trans "Create a New {{ class_name }}" {% templatetag closeblock %}
   {% templatetag openblock %} endif {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   {% templatetag openblock %} if object {% templatetag closeblock %}
     <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
-      {{ class_name }} Update
+      {% templatetag openblock %} trans "{{ class_name }} Update" {% templatetag closeblock %}
     </a>
   {% templatetag openblock %} else {% templatetag closeblock %}
     <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_create {% templatetag closeblock %}'>
-      {{ class_name }} Create
+      {% templatetag openblock %} trans "{{ class_name }} Create" {% templatetag closeblock %}
     </a>
   {% templatetag openblock %} endif {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
   {% templatetag openblock %} if object {% templatetag closeblock %}
-    A view that displays a form for editing an existing object.
+    {% templatetag openblock %} trans "A view that displays a form for editing an existing object." {% templatetag closeblock %}
   {% templatetag openblock %} else {% templatetag closeblock %}
-    A view that displays a form for creating an object.
+    {% templatetag openblock %} trans "A view that displays a form for creating an object." {% templatetag closeblock %}
   {% templatetag openblock %} endif {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
@@ -35,9 +38,9 @@
       <div class='form-actions'>
         <button class='btn btn-large btn-success' type='submit'>
           {% templatetag openblock %} if object {% templatetag closeblock %}
-            Update
+            {% templatetag openblock %} trans "Update" {% templatetag closeblock %}
           {% templatetag openblock %} else {% templatetag closeblock %}
-            Create
+            {% templatetag openblock %} trans "Create" {% templatetag closeblock %}
           {% templatetag openblock %} endif {% templatetag closeblock %}
         </button>
       </div>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_list.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_list.html
@@ -1,18 +1,21 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
+
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_list {% templatetag closeblock %}'>
-    {{ class_name }} List
+    {% templatetag openblock %} trans "{{ class_name }} List" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-description {% templatetag closeblock %}
-  A page representing a list of objects.
+  {% templatetag openblock %} trans "A page representing a list of objects." {% templatetag closeblock %}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block content {% templatetag closeblock %}
   <h2>
-    {{ class_name }}s
+    {% templatetag openblock %} trans "{{ class_name }}s" {% templatetag closeblock %}
   </h2>
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_list.html' {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/pagination.html' {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/base.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/base.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <html>
+  {% templatetag openblock %} load i18n {% templatetag closeblock %}
   <head>
-    <title>{% templatetag openblock %} block title {% templatetag closeblock %}Django Scaffold{% templatetag openblock %} endblock {% templatetag closeblock %}</title>
+    <title>{% templatetag openblock %} block title {% templatetag closeblock %}{% templatetag openblock %} trans "Django Scaffold" {% templatetag closeblock %}{% templatetag openblock %} endblock {% templatetag closeblock %}</title>
     <style type="text/css" media="screen">
       /*!
        * Bootstrap v2.0.3
@@ -659,47 +660,47 @@
             {% templatetag openblock %} block sidebar {% templatetag closeblock %}
                 <ul class='nav nav-list'>
                   <li class='nav-header'>
-                    Views
+                    {% templatetag openblock %} trans "Views" {% templatetag closeblock %}
                   </li>
                   <li>
                     <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_list {% templatetag closeblock %}'>
-                      List View
+                      {% templatetag openblock %} trans "List View" {% templatetag closeblock %}
                     </a>
                   </li>
                   <li>
                     <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_create {% templatetag closeblock %}'>
-                      Create View
+                      {% templatetag openblock %} trans "Create View" {% templatetag closeblock %}
                     </a>
                   </li>
                   {% templatetag openblock %} if object {% templatetag closeblock %}
                     <li>
                       <a href='{% templatetag openvariable %} object.get_absolute_url {% templatetag closevariable %}'>
-                        Detail View
+                        {% templatetag openblock %} trans "Detail View" {% templatetag closeblock %}
                       </a>
                     </li>
                     <li>
                       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
-                        Update View
+                        {% templatetag openblock %} trans "Update View" {% templatetag closeblock %}
                       </a>
                     </li>
                     <li>
                       <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}'>
-                        Delete View
+                        {% templatetag openblock %} trans "Delete View" {% templatetag closeblock %}
                       </a>
                     </li>
                   {% if is_timestamped %}
                   {% templatetag openblock %} endif {% templatetag closeblock %}
                   <li class='nav-header'>
-                    Date-based Views
+                    {% templatetag openblock %} trans "Date-based Views" {% templatetag closeblock %}
                   </li>
                   <li>
                     <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
-                      Archive Index
+                      {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
                     </a>
                   </li>
                   {% templatetag openblock %} if object {% templatetag closeblock %}
                     <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_date_detail year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day pk=object.pk {% templatetag closeblock %}'>
-                      Date Detail View
+                      {% templatetag openblock %} trans "Date Detail View" {% templatetag closeblock %}
                     </a>
                   {% templatetag openblock %} endif {% templatetag closeblock %}
                   {% else %}
@@ -731,9 +732,9 @@
       </div>
       <hr>
       <footer>
-        Presented to you by <a href='http://github.com/modocache/django-generate-scaffold'>django-generate-scaffold</a>.
+        {% templatetag openblock %} trans "Presented to you by <a href='http://github.com/modocache/django-generate-scaffold'>django-generate-scaffold</a>." {% templatetag closeblock %}
         <br>
-        Edit this template file in <code>{% templatetag openblock %} block filename {% templatetag closeblock %}the templates directory!{% templatetag openblock %} endblock {% templatetag closeblock %}</code>
+        {% templatetag openblock %} trans "Edit this template file in:" {% templatetag closeblock %} <code>{% templatetag openblock %} block filename {% templatetag closeblock %}the templates directory!{% templatetag openblock %} endblock {% templatetag closeblock %}</code>
       </footer>
     </div>
   </body>

--- a/generate_scaffold/templates/generate_scaffold/tpls/object_table_detail.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/object_table_detail.html
@@ -1,11 +1,13 @@
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 <table class='table table-bordered table-striped'>
   <thead>
     <tr>
       <th>
-        Field
+        {% templatetag openblock %} trans "Field" {% templatetag closeblock %}
       </th>
       <th>
-        Value
+        {% templatetag openblock %} trans "Value" {% templatetag closeblock %}
       </th>
     </tr>
   </thead>

--- a/generate_scaffold/templates/generate_scaffold/tpls/object_table_list.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/object_table_list.html
@@ -1,5 +1,7 @@
+{% templatetag openblock %} load i18n {% templatetag closeblock %}
+
 <p>
-  Click on the primary key value to access the individual {{ class_name }}'s page.
+  {% templatetag openblock %} trans "Click on the primary key value to access the individual {{ class_name }}'s page." {% templatetag closeblock %}
 </p>
 <table class='table table-bordered table-striped'>
   <thead>

--- a/test_project/test_app/tests/functional_tests/generated_tests/archive_month_tests.py
+++ b/test_project/test_app/tests/functional_tests/generated_tests/archive_month_tests.py
@@ -13,8 +13,6 @@ class ArchiveMonthTest(unittest.TestCase, SeleniumTestCaseMixin):
     def test_ok(self):
         s = self.selenium
         self.failUnless(s.is_text_present('GeneratedModel Month Archive'))
-        self.failUnless(s.is_text_present(
-            'GeneratedModels created in the month of Aug 2012'))
         self.failUnless(s.is_text_present('Generated Model Fixture'))
 
     # FIXME


### PR DESCRIPTION
- Add translation tags to generated templates, allowing users to create
  translations for scaffold templates.
- See Github Issue #6: "Support i18n", at
  https://github.com/modocache/django-generate-scaffold/issues/6
