### PR TITLE
Django 1.5 support

### DIFF
--- a/generate_scaffold/generators/templates.py
+++ b/generate_scaffold/generators/templates.py
@@ -1,5 +1,6 @@
 import os
 
+from django import VERSION as DJANGO_VERSION
 from django.template import Context
 from django.template.defaultfilters import slugify
 from django.template.loader import get_template
@@ -27,6 +28,10 @@ class TemplatesGenerator(BaseGenerator):
             model, timestamp_fieldname)
         is_timestamped = True if timestamp_field else False
 
+        context_keys = {
+            'year': 'year.year' if DJANGO_VERSION >= (1, 5) else 'year'
+        }
+
         for template_template in template_templates:
 
             if not is_timestamped and '_archive' in template_template:
@@ -44,6 +49,7 @@ class TemplatesGenerator(BaseGenerator):
                 'class_name': class_name,
                 'filename': dst_abspath,
                 'is_timestamped': is_timestamped,
+                'context_keys': context_keys
             }
             if is_timestamped:
                 c['timestamp_field'] = timestamp_field.name

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -13,14 +14,14 @@
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Archive Index" %}" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Archive Index{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
@@ -34,7 +35,7 @@
   <ul class='nav nav-tabs nav-stacked'>
     {% templatetag openblock %} for date in date_list {% templatetag closeblock %}
       <li>
-        <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=date.year {% templatetag closeblock %}'>
+        <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=date.year {% templatetag closeblock %}'>
           {% templatetag openvariable %} date.year {% templatetag closevariable %}
         </a>
       </li>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_day.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_day.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -13,7 +14,7 @@
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Archive Index" %}" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -21,7 +22,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=day.year {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=day.year {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Year Archive" %}" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -29,7 +30,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=day.year month=day.month {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_month_archive' year=day.year month=day.month {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Month Archive" %}" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -37,14 +38,14 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=day.year month=day.month day=day.day {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_day_archive' year=day.year month=day.month day=day.day {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Day Archive" %}" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=day.year month=day.month day=day.day {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_day_archive' year=day.year month=day.month day=day.day {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Day Archive{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_month.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_month.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -10,7 +11,7 @@
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -18,7 +19,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=month.year {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=month.year {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Year Archive" %}" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -26,14 +27,14 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=month.year month=month.month {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_month_archive' year=month.year month=month.month {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Month Archive" %}" {% templatetag closeblock %}
       </a>
     </li>
   </ul>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=month.year month=month.month {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_month_archive' year=month.year month=month.month {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Month Archive{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
@@ -47,7 +48,7 @@
   <ul class='nav nav-tabs nav-stacked'>
     {% templatetag openblock %} for date in date_list {% templatetag closeblock %}
       <li>
-        <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=date.year month=date.month day=date.day {% templatetag closeblock %}'>
+        <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_day_archive' year=date.year month=date.month day=date.day {% templatetag closeblock %}'>
           {% templatetag openvariable %} date|date:"M. d, Y" {% templatetag closevariable %}
         </a>
       </li>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_year.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_year.html
@@ -20,7 +20,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=year {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year={{ context_keys.year }} {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Year Archive" %}" {% templatetag closeblock %}
       </a>
     </li>
@@ -28,7 +28,7 @@
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=year {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year={{ context_keys.year }} {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Year Archive{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_year.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_archive_year.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -11,7 +12,7 @@
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Archive Index" %}" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -19,7 +20,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=year {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=year {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "{% trans "Year Archive" %}" {% templatetag closeblock %}
       </a>
     </li>
@@ -27,7 +28,7 @@
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=year {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=year {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Year Archive{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}
@@ -41,7 +42,7 @@
   <ul class='nav nav-tabs nav-stacked'>
     {% templatetag openblock %} for date in date_list {% templatetag closeblock %}
       <li>
-        <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=date.year month=date.month {% templatetag closeblock %}'>
+        <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_month_archive' year=date.year month=date.month {% templatetag closeblock %}'>
           {% templatetag openvariable %} date|date:"M Y" {% templatetag closevariable %}
         </a>
       </li>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_confirm_delete.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_confirm_delete.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -13,7 +14,7 @@
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_delete' pk=object.pk {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Confirm Delete{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_detail.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_detail.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -16,7 +17,7 @@
 {% templatetag openblock %} block breadcrumbs {% templatetag closeblock %}
   <ul class='breadcrumb'>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "Archive Index" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -24,7 +25,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_year_archive year=object.{{ timestamp_field }}.year {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_year_archive' year=object.{{ timestamp_field }}.year {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "Year Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -32,7 +33,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_month_archive year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_month_archive' year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "Month Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -40,7 +41,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_day_archive year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_day_archive' year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "Day Archive" {% templatetag closeblock %}
       </a>
       <span class='divider'>
@@ -48,7 +49,7 @@
       </span>
     </li>
     <li>
-      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_date_detail year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day pk=object.pk {% templatetag closeblock %}'>
+      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_date_detail' year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day pk=object.pk {% templatetag closeblock %}'>
         {% templatetag openblock %} trans "Date Detail" {% templatetag closeblock %}
       </a>
     </li>
@@ -68,11 +69,11 @@
 
 {% templatetag openblock %} block content {% templatetag closeblock %}
   {% templatetag openblock %} include '{{ app_name }}/{{ model_slug }}/object_table_detail.html' {% templatetag closeblock %}
-  <form action='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}' charset='utf-8' method='post'>
+  <form action='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_delete' pk=object.pk {% templatetag closeblock %}' charset='utf-8' method='post'>
     <fieldset>
       {% templatetag openblock %} csrf_token {% templatetag closeblock %}
       <div class='form-actions'>
-        <a class='btn btn-success' href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
+        <a class='btn btn-success' href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_update' pk=object.pk {% templatetag closeblock %}'>
           {% templatetag openblock %} trans "Update" {% templatetag closeblock %}
         </a>
         <button class='btn btn-danger' type='submit'>

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_form.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_form.html
@@ -3,6 +3,7 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
@@ -18,11 +19,11 @@
 
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
   {% templatetag openblock %} if object {% templatetag closeblock %}
-    <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
+    <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_update' pk=object.pk {% templatetag closeblock %}'>
       {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Update{% endblocktrans %}" {% templatetag closeblock %}
     </a>
   {% templatetag openblock %} else {% templatetag closeblock %}
-    <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_create {% templatetag closeblock %}'>
+    <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_create' {% templatetag closeblock %}'>
       {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} Create{% endblocktrans %}" {% templatetag closeblock %}
     </a>
   {% templatetag openblock %} endif {% templatetag closeblock %}
@@ -37,7 +38,7 @@
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block content {% templatetag closeblock %}
-  <form action='{% templatetag openblock %} if object {% templatetag closeblock %}{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}{% templatetag openblock %} else {% templatetag closeblock %}{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_create {% templatetag closeblock %}{% templatetag openblock %} endif {% templatetag closeblock %}' method='post' encoding='utf-8'>
+  <form action='{% templatetag openblock %} if object {% templatetag closeblock %}{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_update' pk=object.pk {% templatetag closeblock %}{% templatetag openblock %} else {% templatetag closeblock %}{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_create' {% templatetag closeblock %}{% templatetag openblock %} endif {% templatetag closeblock %}' method='post' encoding='utf-8'>
     <fieldset>
       {% templatetag openblock %} csrf_token {% templatetag closeblock %}
       {% templatetag openvariable %} form {% templatetag closevariable %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_list.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/MODEL_NAME_list.html
@@ -3,13 +3,14 @@
 {% templatetag openblock %} extends '{{ app_name }}/{{ model_slug }}/base.html' {% templatetag closeblock %}
 
 {% templatetag openblock %} load i18n {% templatetag closeblock %}
+{% templatetag openblock %} load url from future {% templatetag closeblock %}
 
 {% templatetag openblock %} block filename {% templatetag closeblock %}
   {{ filename }}
 {% templatetag openblock %} endblock {% templatetag closeblock %}
 
 {% templatetag openblock %} block header-link {% templatetag closeblock %}
-  <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_list {% templatetag closeblock %}'>
+  <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_list' {% templatetag closeblock %}'>
     {% templatetag openblock %} trans "{% blocktrans %}{{ class_name }} List{% endblocktrans %}" {% templatetag closeblock %}
   </a>
 {% templatetag openblock %} endblock {% templatetag closeblock %}

--- a/generate_scaffold/templates/generate_scaffold/tpls/base.html
+++ b/generate_scaffold/templates/generate_scaffold/tpls/base.html
@@ -3,6 +3,7 @@
 <!DOCTYPE html>
 <html>
   {% templatetag openblock %} load i18n {% templatetag closeblock %}
+  {% templatetag openblock %} load url from future {% templatetag closeblock %}
   <head>
     <title>
       {% templatetag openblock %} block title {% templatetag closeblock %}
@@ -655,7 +656,7 @@
         <div class='page-header site-header'>
           <h1>
             {% templatetag openblock %} block header {% templatetag closeblock %}
-              <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_list {% templatetag closeblock %}'>
+              <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_list' {% templatetag closeblock %}'>
                 {% templatetag openblock %} trans "{{ class_name }}s" {% templatetag closeblock %}
               </a>
             {% templatetag openblock %} endblock {% templatetag closeblock %}
@@ -669,12 +670,12 @@
                     {% templatetag openblock %} trans "{% trans "Views" %}" {% templatetag closeblock %}
                   </li>
                   <li>
-                    <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_list {% templatetag closeblock %}'>
+                    <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_list' {% templatetag closeblock %}'>
                       {% templatetag openblock %} trans "{% trans "List View" %}" {% templatetag closeblock %}
                     </a>
                   </li>
                   <li>
-                    <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_create {% templatetag closeblock %}'>
+                    <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_create' {% templatetag closeblock %}'>
                       {% templatetag openblock %} trans "{% trans "Create View" %}" {% templatetag closeblock %}
                     </a>
                   </li>
@@ -685,12 +686,12 @@
                       </a>
                     </li>
                     <li>
-                      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_update pk=object.pk {% templatetag closeblock %}'>
+                      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_update' pk=object.pk {% templatetag closeblock %}'>
                         {% templatetag openblock %} trans "{% trans "Update View" %}" {% templatetag closeblock %}
                       </a>
                     </li>
                     <li>
-                      <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_delete pk=object.pk {% templatetag closeblock %}'>
+                      <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_delete' pk=object.pk {% templatetag closeblock %}'>
                         {% templatetag openblock %} trans "{% trans "Delete View" %}" {% templatetag closeblock %}
                       </a>
                     </li>
@@ -700,12 +701,12 @@
                     {% templatetag openblock %} trans "{% trans "Date-based Views" %}" {% templatetag closeblock %}
                   </li>
                   <li>
-                    <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_archive_index {% templatetag closeblock %}'>
+                    <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_archive_index' {% templatetag closeblock %}'>
                       {% templatetag openblock %} trans "{% trans "Archive Index" %}" {% templatetag closeblock %}
                     </a>
                   </li>
                   {% templatetag openblock %} if object {% templatetag closeblock %}
-                    <a href='{% templatetag openblock %} url {{ app_name }}_{{ model_slug }}_date_detail year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day pk=object.pk {% templatetag closeblock %}'>
+                    <a href='{% templatetag openblock %} url '{{ app_name }}_{{ model_slug }}_date_detail' year=object.{{ timestamp_field }}.year month=object.{{ timestamp_field }}.month day=object.{{ timestamp_field }}.day pk=object.pk {% templatetag closeblock %}'>
                       {% templatetag openblock %} trans "{% trans "Date Detail View" %}" {% templatetag closeblock %}
                     </a>
                   {% templatetag openblock %} endif {% templatetag closeblock %}


### PR DESCRIPTION
**Put quotes around the first parameter of url template tags**

The first parameter do not allow unquoted string since Django 1.5.

**Add context_keys to TemplatesGenerator**

MODEL_NAME_archive_year.html uses 'year' the context of YearArchiveView.

But, on Django 1.5, it is returned as a date object.

So the template must use 'year.year'.

In order to maintain backward compatibility, add context_keys and set proper key depending on the version of Django.
